### PR TITLE
Ability to change path separator in ResponseUrlScroller

### DIFF
--- a/Pagination/ResponseUrlScroller.php
+++ b/Pagination/ResponseUrlScroller.php
@@ -25,6 +25,11 @@ class ResponseUrlScroller extends AbstractResponseScroller implements ScrollerIn
      * @var bool
      */
     protected $paramIsQuery = false;
+    
+    /**
+     * @var string
+     */
+    protected $pathSeparator = '.';
 
     /**
      * ResponseUrlScroller constructor.
@@ -33,6 +38,7 @@ class ResponseUrlScroller extends AbstractResponseScroller implements ScrollerIn
      *          'urlKey' => string // Key in the JSON response containing the URL
      *          'includeParams' => bool // Whether to include params from config
      *          'paramIsQuery' => bool // Pick parameters from the scroll URL and use them with job configuration
+     *          'pathSeparator' => string // Data path separator char
      *      ]
      */
     public function __construct($config)
@@ -46,6 +52,9 @@ class ResponseUrlScroller extends AbstractResponseScroller implements ScrollerIn
         if (isset($config['paramIsQuery'])) {
             $this->paramIsQuery = (bool)$config['paramIsQuery'];
         }
+        if (isset($config['pathSeparator'])) {
+            $this->pathSeparator = $config['pathSeparator'];
+        }
     }
 
     /**
@@ -53,7 +62,7 @@ class ResponseUrlScroller extends AbstractResponseScroller implements ScrollerIn
      */
     public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
     {
-        $nextUrl = \Keboola\Utils\getDataFromPath($this->urlParam, $response, '.');
+        $nextUrl = \Keboola\Utils\getDataFromPath($this->urlParam, $response, $this->pathSeparator);
 
         if (empty($nextUrl)) {
             return false;


### PR DESCRIPTION
While trying to use generic extractor i have problem with using on Microsoft Graph API. Problem is in pagination section. Due documentation https://docs.microsoft.com/en-us/graph/paging Microsoft is using next page url in response. Problem is that dot (.) is character that is ResponseUrlScroller using to parse nested object parameters. So there is no way to use:

```  
"pagination": {
    "method": "response.url",
    "urlKey": "@odata.nextLink"
},
```

This solution is trying to add `pathSeparator` parameter to JSON configuration of pagination